### PR TITLE
Change site link for 3H San Francisco group

### DIFF
--- a/_groups/san-francisco.md
+++ b/_groups/san-francisco.md
@@ -3,7 +3,7 @@ title: "3H San Francisco"
 image: "/assets/images/highres_476845972.jpeg"
 group: san-francisco
 twitter:
-site: https://www.meetup.com/hardwarehappyhoursf/
+site: https://luma.com/3HSF
 appetizer:
 ---
 Sometimes the formality of meetups is too much. This group exists to socialize and show off your latest piece of hardware. If it's a simple Arduino based thingamabob or your company's newest hardware product (and how you earn your living), you should consider attending. The main focus is meeting like minded people who are building fun things (with atoms!)


### PR DESCRIPTION
SF group switched to luma (you can see the change in the links in Discord, but it seems it wasn't updated here)